### PR TITLE
fix: Add docs/ folder to CODEOWNERS search path

### DIFF
--- a/src/show-owners-command.ts
+++ b/src/show-owners-command.ts
@@ -15,7 +15,7 @@ async function fileExists(path: string): Promise<boolean> {
     return false
   }
 }
-const PathOptions = [".github/CODEOWNERS", "CODEOWNERS"]
+const PathOptions = [".github/CODEOWNERS", "docs/CODEOWNERS", "CODEOWNERS"]
 
 async function findCodeOwnersFile(
   startDirectory: string,


### PR DESCRIPTION
Add `docs/` to the list of locations to search for a CODEOWNERS file. The `docs/` folder is often suggested as a source folder in the Github Pages documentation, hence, some team/orgs may use a CODEOWNERS file for it (especially if the repo is just for documentation.)

ref: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location
