### PR TITLE
feat: Add GHES support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 3.2.0 - 2023-08-16
+
+### Added
+
+- GitHub Enterprise support (#23). Thanks @jeffstoner!
+
 ## 3.1.0 - 2023-08-08
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Quickly see GitHub Code Owners for the current file. Add syntax highlighting for CODEOWNERS files.",
   "publisher": "chdsbd",
   "license": "SEE LICENSE IN LICENSE",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "icon": "images/logo256.png",
   "homepage": "https://github.com/chdsbd/vscode-github-code-owners/blob/master/README.md",
   "keywords": [

--- a/src/github-usernames-link-provider.ts
+++ b/src/github-usernames-link-provider.ts
@@ -15,14 +15,17 @@ function githubUserToUrl(username: string): vscode.Uri {
 function getGitHubUrl(): string {
   /*
    * When using GitHub Enterprise Server, you should have a 'github-enterprise.uri'
-   * configuration setting. Let's see if we have one of those.
+   * configuration setting.
+   *
+   * This configuration option is provided by built in "GitHub Authentication" extension
+   * https://github.com/microsoft/vscode/blob/ccb95fd921349023027a0df25ed291b0992b9a18/extensions/github-authentication/src/extension.ts#L10
    */
-  const setting = vscode.workspace.getConfiguration().get<string>('github-enterprise.uri')
+  const setting = vscode.workspace
+    .getConfiguration()
+    .get<string>("github-enterprise.uri")
   if (!setting) {
-    // Doesn't appear to be a GHES workspace
-    return 'https://github.com'
+    return "https://github.com"
   }
-
   return setting
 }
 

--- a/src/github-usernames-link-provider.ts
+++ b/src/github-usernames-link-provider.ts
@@ -3,12 +3,27 @@ import { findUsernameRanges } from "./owner-name-completion-item-provider"
 
 function githubUserToUrl(username: string): vscode.Uri {
   const isTeamName = username.includes("/")
+  const gitHubUrl = getGitHubUrl()
 
   if (isTeamName) {
     const [org, name] = username.split(/\//)
-    return vscode.Uri.parse(`https://github.com/orgs/${org}/teams/${name}`)
+    return vscode.Uri.parse(gitHubUrl + `/orgs/${org}/teams/${name}`)
   }
-  return vscode.Uri.parse(`https://github.com/${username}`)
+  return vscode.Uri.parse(gitHubUrl + `/${username}`)
+}
+
+function getGitHubUrl(): string {
+  /*
+   * When using GitHub Enterprise Server, you should have a 'github-enterprise.uri'
+   * configuration setting. Let's see if we have one of those.
+   */
+  const setting = vscode.workspace.getConfiguration().get<string>('github-enterprise.uri')
+  if (!setting) {
+    // Doesn't appear to be a GHES workspace
+    return 'https://github.com'
+  }
+
+  return setting
 }
 
 /**


### PR DESCRIPTION
This PR adds support for generating user and team links when VSCode is configured with a Github Enterprise Server authentication provider, as suggested in #22 .

One consequence is links to users and teams will use the GHES url when switching to a repo that was cloned from github.com. This is an issue any plugin will face in this scenario and not unique to this one. In situations like this, it may be advisable for users to utilize VSCode's Workspace feature, keeping GHES-based repos in one Workspace and Github.com-based repos in another while syncing their extensions and settings appropriately.